### PR TITLE
Fixes typo in characterSetResults in the jdbc uri and

### DIFF
--- a/mill-db-repo/src/main/java/org/duracloud/mill/db/repo/MillJpaRepoConfig.java
+++ b/mill-db-repo/src/main/java/org/duracloud/mill/db/repo/MillJpaRepoConfig.java
@@ -57,7 +57,7 @@ public class MillJpaRepoConfig {
                                                "?useLegacyDatetimeCode=false" +
                                                "&serverTimezone=GMT" +
                                                "&characterEncoding=utf8" +
-                                               "&characxterSetResults=utf8",
+                                               "&characterSetResults=utf8",
                                                env.getProperty("mill.db.host", "localhost"),
                                                env.getProperty("mill.db.port", "3306"),
                                                env.getProperty("mill.db.name", "mill")));


### PR DESCRIPTION
adds integration test.
https://jira.duraspace.org/browse/DURACLOUD-1178 inspired this change. While this update doesn't fix the problem in duracloud-1178 it does improve the code and at least prove that the problem doesn't appear to be caused by this type.