### PR TITLE
Add SWIFT_S3 as a storage provider

### DIFF
--- a/account-management-db-model/src/main/java/org/duracloud/storage/domain/StorageProviderType.java
+++ b/account-management-db-model/src/main/java/org/duracloud/storage/domain/StorageProviderType.java
@@ -10,6 +10,7 @@ package org.duracloud.storage.domain;
 public enum StorageProviderType {
     AMAZON_S3("amazon-s3"),
     AMAZON_GLACIER("amazon-glacier"),
+    SWIFT_S3("swift-s3"),
     IRODS("irods"),
     CHRONOPOLIS("chronopolis"),
     UNKNOWN("unknown"),


### PR DESCRIPTION
In anticipation of other Duracloud components supporting a Swift with S3
middleware storage backend.