### PR TITLE
Add config parameters for RabbitMQ, Spring email and Swift

### DIFF
--- a/account-management-db-model/src/main/java/org/duracloud/account/db/model/DuracloudMill.java
+++ b/account-management-db-model/src/main/java/org/duracloud/account/db/model/DuracloudMill.java
@@ -30,34 +30,22 @@ public class DuracloudMill extends BaseEntity {
     private String dbPassword;
     @Column(nullable = false)
     private String auditQueue;
-    // Must specify column name explicitly because the number
-    // breaks the auto parsing from field name
-    @Column(nullable = false, name = "s3_type")
-    private String s3Type;
     @Column(nullable = false)
     private String auditLogSpaceId;
     @Column(nullable = false)
     private String auditQueueType;
-    @Column(nullable = false)
-    private String rabbitmqHost;
-    @Column(nullable = false)
-    private Integer rabbitmqPort;
-    @Column(nullable = false)
-    private String rabbitmqVhost;
-    @Column(nullable = false)
-    private String rabbitmqExchange;
-    @Column(nullable = false)
-    private String rabbitmqUsername;
-    @Column(nullable = false)
-    private String rabbitmqPassword;
-    @Column(nullable = false)
-    private String awsAccessKey;
-    @Column(nullable = false)
-    private String awsSecretKey;
-    @Column(nullable = false)
-    private String swiftEndpoint;
     @Column(nullable = true)
-    private String swiftSignerType;
+    private String rabbitmqHost;
+    @Column(nullable = true)
+    private Integer rabbitmqPort;
+    @Column(nullable = true)
+    private String rabbitmqVhost;
+    @Column(nullable = true)
+    private String rabbitmqExchange;
+    @Column(nullable = true)
+    private String rabbitmqUsername;
+    @Column(nullable = true)
+    private String rabbitmqPassword;
 
     public String getDbName() {
         return dbName;
@@ -105,14 +93,6 @@ public class DuracloudMill extends BaseEntity {
 
     public void setAuditQueue(String auditQueue) {
         this.auditQueue = auditQueue;
-    }
-
-    public String getS3Type() {
-        return s3Type;
-    }
-
-    public void setS3Type(String s3Type) {
-        this.s3Type = s3Type;
     }
 
     public String getAuditLogSpaceId() {
@@ -177,37 +157,5 @@ public class DuracloudMill extends BaseEntity {
 
     public void setRabbitmqPassword(String rabbitmqPassword) {
         this.rabbitmqPassword = rabbitmqPassword;
-    }
-
-    public String getAwsAccessKey() {
-        return awsAccessKey;
-    }
-
-    public void setAwsAccessKey(String awsAccessKey) {
-        this.awsAccessKey = awsAccessKey;
-    }
-
-    public String getAwsSecretKey() {
-        return awsSecretKey;
-    }
-
-    public void setAwsSecretKey(String awsSecretKey) {
-        this.awsSecretKey = awsSecretKey;
-    }
-
-    public String getSwiftEndpoint() {
-        return swiftEndpoint;
-    }
-
-    public void setSwiftEndpoint(String swiftEndpoint) {
-        this.swiftEndpoint = swiftEndpoint;
-    }
-
-    public String getSwiftSignerType() {
-        return swiftSignerType;
-    }
-
-    public void setSwiftSignerType(String swiftSignerType) {
-        this.swiftSignerType = swiftSignerType;
     }
 }

--- a/account-management-db-model/src/main/java/org/duracloud/account/db/model/DuracloudMill.java
+++ b/account-management-db-model/src/main/java/org/duracloud/account/db/model/DuracloudMill.java
@@ -30,7 +30,9 @@ public class DuracloudMill extends BaseEntity {
     private String dbPassword;
     @Column(nullable = false)
     private String auditQueue;
-    @Column(nullable = false)
+    // Must specify column name explicitly because the number
+    // breaks the auto parsing from field name
+    @Column(nullable = false, name = "s3_type")
     private String s3Type;
     @Column(nullable = false)
     private String auditLogSpaceId;

--- a/account-management-db-model/src/main/java/org/duracloud/account/db/model/DuracloudMill.java
+++ b/account-management-db-model/src/main/java/org/duracloud/account/db/model/DuracloudMill.java
@@ -31,6 +31,8 @@ public class DuracloudMill extends BaseEntity {
     @Column(nullable = false)
     private String auditQueue;
     @Column(nullable = false)
+    private String s3Type;
+    @Column(nullable = false)
     private String auditLogSpaceId;
     @Column(nullable = false)
     private String auditQueueType;
@@ -46,6 +48,14 @@ public class DuracloudMill extends BaseEntity {
     private String rabbitmqUsername;
     @Column(nullable = false)
     private String rabbitmqPassword;
+    @Column(nullable = false)
+    private String awsAccessKey;
+    @Column(nullable = false)
+    private String awsSecretKey;
+    @Column(nullable = false)
+    private String swiftEndpoint;
+    @Column(nullable = true)
+    private String swiftSignerType;
 
     public String getDbName() {
         return dbName;
@@ -93,6 +103,14 @@ public class DuracloudMill extends BaseEntity {
 
     public void setAuditQueue(String auditQueue) {
         this.auditQueue = auditQueue;
+    }
+
+    public String getS3Type() {
+        return s3Type;
+    }
+
+    public void setS3Type(String s3Type) {
+        this.s3Type = s3Type;
     }
 
     public String getAuditLogSpaceId() {
@@ -159,4 +177,35 @@ public class DuracloudMill extends BaseEntity {
         this.rabbitmqPassword = rabbitmqPassword;
     }
 
+    public String getAwsAccessKey() {
+        return awsAccessKey;
+    }
+
+    public void setAwsAccessKey(String awsAccessKey) {
+        this.awsAccessKey = awsAccessKey;
+    }
+
+    public String getAwsSecretKey() {
+        return awsSecretKey;
+    }
+
+    public void setAwsSecretKey(String awsSecretKey) {
+        this.awsSecretKey = awsSecretKey;
+    }
+
+    public String getSwiftEndpoint() {
+        return swiftEndpoint;
+    }
+
+    public void setSwiftEndpoint(String swiftEndpoint) {
+        this.swiftEndpoint = swiftEndpoint;
+    }
+
+    public String getSwiftSignerType() {
+        return swiftSignerType;
+    }
+
+    public void setSwiftSignerType(String swiftSignerType) {
+        this.swiftSignerType = swiftSignerType;
+    }
 }

--- a/account-management-db-model/src/main/java/org/duracloud/account/db/model/DuracloudMill.java
+++ b/account-management-db-model/src/main/java/org/duracloud/account/db/model/DuracloudMill.java
@@ -33,7 +33,7 @@ public class DuracloudMill extends BaseEntity {
     @Column(nullable = false)
     private String auditLogSpaceId;
     @Column(nullable = false)
-    private String auditQueueType;
+    private String queueType;
     @Column(nullable = true)
     private String rabbitmqHost;
     @Column(nullable = true)
@@ -103,12 +103,12 @@ public class DuracloudMill extends BaseEntity {
         this.auditLogSpaceId = auditLogSpaceId;
     }
 
-    public String getAuditQueueType() {
-        return auditQueueType;
+    public String getQueueType() {
+        return queueType;
     }
 
-    public void setAuditQueueType(String auditQueueType) {
-        this.auditQueueType = auditQueueType;
+    public void setQueueType(String queueType) {
+        this.queueType = queueType;
     }
 
     public String getRabbitmqHost() {

--- a/account-management-db-model/src/main/java/org/duracloud/account/db/model/DuracloudMill.java
+++ b/account-management-db-model/src/main/java/org/duracloud/account/db/model/DuracloudMill.java
@@ -32,6 +32,20 @@ public class DuracloudMill extends BaseEntity {
     private String auditQueue;
     @Column(nullable = false)
     private String auditLogSpaceId;
+    @Column(nullable = false)
+    private String auditQueueType;
+    @Column(nullable = false)
+    private String rabbitmqHost;
+    @Column(nullable = false)
+    private Integer rabbitmqPort;
+    @Column(nullable = false)
+    private String rabbitmqVhost;
+    @Column(nullable = false)
+    private String rabbitmqExchange;
+    @Column(nullable = false)
+    private String rabbitmqUsername;
+    @Column(nullable = false)
+    private String rabbitmqPassword;
 
     public String getDbName() {
         return dbName;
@@ -87,6 +101,62 @@ public class DuracloudMill extends BaseEntity {
 
     public void setAuditLogSpaceId(String auditLogSpaceId) {
         this.auditLogSpaceId = auditLogSpaceId;
+    }
+
+    public String getAuditQueueType() {
+        return auditQueueType;
+    }
+
+    public void setAuditQueueType(String auditQueueType) {
+        this.auditQueueType = auditQueueType;
+    }
+
+    public String getRabbitmqHost() {
+        return rabbitmqHost;
+    }
+
+    public void setRabbitmqHost(String rabbitmqHost) {
+        this.rabbitmqHost = rabbitmqHost;
+    }
+
+    public Integer getRabbitmqPort() {
+        return rabbitmqPort;
+    }
+
+    public void setRabbitmqPort(Integer rabbitmqPort) {
+        this.rabbitmqPort = rabbitmqPort;
+    }
+
+    public String getRabbitmqVhost() {
+        return rabbitmqVhost;
+    }
+
+    public void setRabbitmqVhost(String rabbitmqVhost) {
+        this.rabbitmqVhost = rabbitmqVhost;
+    }
+
+    public String getRabbitmqExchange() {
+        return rabbitmqExchange;
+    }
+
+    public void setRabbitmqExchange(String rabbitmqExchange) {
+        this.rabbitmqExchange = rabbitmqExchange;
+    }
+
+    public String getRabbitmqUsername() {
+        return rabbitmqUsername;
+    }
+
+    public void setRabbitmqUsername(String rabbitmqUsername) {
+        this.rabbitmqUsername = rabbitmqUsername;
+    }
+
+    public String getRabbitmqPassword() {
+        return rabbitmqPassword;
+    }
+
+    public void setRabbitmqPassword(String rabbitmqPassword) {
+        this.rabbitmqPassword = rabbitmqPassword;
     }
 
 }

--- a/account-management-db-model/src/main/java/org/duracloud/account/db/model/GlobalProperties.java
+++ b/account-management-db-model/src/main/java/org/duracloud/account/db/model/GlobalProperties.java
@@ -36,22 +36,22 @@ public class GlobalProperties extends BaseEntity {
     @Column(nullable = false)
     private String notifierType;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String rabbitmqHost;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private Integer rabbitmqPort;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String rabbitmqVhost;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String rabbitmqExchange;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String rabbitmqUsername;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String rabbitmqPassword;
 
     public String getInstanceNotificationTopicArn() {

--- a/account-management-db-model/src/main/java/org/duracloud/account/db/model/GlobalProperties.java
+++ b/account-management-db-model/src/main/java/org/duracloud/account/db/model/GlobalProperties.java
@@ -21,7 +21,7 @@ public class GlobalProperties extends BaseEntity {
     /*
      * an SNS topic arn for sending noticiations to the instances
      */
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String instanceNotificationTopicArn;
 
     @Column(nullable = false)

--- a/account-management-db-model/src/main/java/org/duracloud/account/db/model/GlobalProperties.java
+++ b/account-management-db-model/src/main/java/org/duracloud/account/db/model/GlobalProperties.java
@@ -103,22 +103,18 @@ public class GlobalProperties extends BaseEntity {
     }
 
     public Integer getRabbitmqPort() {
-
         return rabbitmqPort;
     }
 
     public void setRabbitmqPort(Integer rabbitmqPort) {
-
         this.rabbitmqPort = rabbitmqPort;
     }
 
     public String getRabbitmqVhost() {
-
         return rabbitmqVhost;
     }
 
     public void setRabbitmqVhost(String rabbitmqVhost) {
-
         this.rabbitmqVhost = rabbitmqVhost;
     }
 

--- a/account-management-db-model/src/main/java/org/duracloud/account/db/model/GlobalProperties.java
+++ b/account-management-db-model/src/main/java/org/duracloud/account/db/model/GlobalProperties.java
@@ -33,6 +33,27 @@ public class GlobalProperties extends BaseEntity {
     @Column(nullable = false)
     private String cloudFrontKeyPath;
 
+    @Column(nullable = false)
+    private String notifierType;
+
+    @Column(nullable = false)
+    private String rabbitmqHost;
+
+    @Column(nullable = false)
+    private Integer rabbitmqPort;
+
+    @Column(nullable = false)
+    private String rabbitmqVhost;
+
+    @Column(nullable = false)
+    private String rabbitmqExchange;
+
+    @Column(nullable = false)
+    private String rabbitmqUsername;
+
+    @Column(nullable = false)
+    private String rabbitmqPassword;
+
     public String getInstanceNotificationTopicArn() {
         return instanceNotificationTopicArn;
     }
@@ -65,4 +86,63 @@ public class GlobalProperties extends BaseEntity {
         this.cloudFrontKeyPath = cloudFrontKeyPath;
     }
 
+    public String getNotifierType() {
+        return notifierType;
+    }
+
+    public void setNotifierType(String notifierType) {
+        this.notifierType = notifierType;
+    }
+
+    public String getRabbitmqHost() {
+        return rabbitmqHost;
+    }
+
+    public void setRabbitmqHost(String rabbitmqHost) {
+        this.rabbitmqHost = rabbitmqHost;
+    }
+
+    public Integer getRabbitmqPort() {
+
+        return rabbitmqPort;
+    }
+
+    public void setRabbitmqPort(Integer rabbitmqPort) {
+
+        this.rabbitmqPort = rabbitmqPort;
+    }
+
+    public String getRabbitmqVhost() {
+
+        return rabbitmqVhost;
+    }
+
+    public void setRabbitmqVhost(String rabbitmqVhost) {
+
+        this.rabbitmqVhost = rabbitmqVhost;
+    }
+
+    public String getRabbitmqExchange() {
+        return rabbitmqExchange;
+    }
+
+    public void setRabbitmqExchange(String rabbitmqExchange) {
+        this.rabbitmqExchange = rabbitmqExchange;
+    }
+
+    public String getRabbitmqUsername() {
+        return rabbitmqUsername;
+    }
+
+    public void setRabbitmqUsername(String rabbitmqUsername) {
+        this.rabbitmqUsername = rabbitmqUsername;
+    }
+
+    public String getRabbitmqPassword() {
+        return rabbitmqPassword;
+    }
+
+    public void setRabbitmqPassword(String rabbitmqPassword) {
+        this.rabbitmqPassword = rabbitmqPassword;
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
   <version>6.2.0-SNAPSHOT</version>
   <name>DuraCloud DB</name>
   <description>DuraCloud Database Management</description>
-  <url>http://duracloud.org</url>
+  <url>https://duracloud.org</url>
 
   <prerequisites>
     <maven>3.0.0</maven>
@@ -36,13 +36,13 @@
   <licenses>
     <license>
       <name>Apache License, Version 2.0</name>
-      <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+      <url>https://www.apache.org/licenses/LICENSE-2.0</url>
     </license>
   </licenses>
 
   <organization>
-    <name>DuraSpace</name>
-    <url>http://www.duraspace.org</url>
+    <name>LYRASIS</name>
+    <url>https://lyrasis.org</url>
   </organization>
 
   <scm>
@@ -190,7 +190,7 @@
     <repository>
       <id>central</id>
       <name>Maven Repository Switchboard</name>
-      <url>http://repo1.maven.org/maven2</url>
+      <url>https://repo1.maven.org/maven2</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>


### PR DESCRIPTION
This PR includes commits that introduce new columns into the db models, allowing for extra configuration parameters that are required if one wants to use RabbitMQ as an SQS replacement, Spring email as an SES/SNS replacement, or Swift object storage as a replacement for duplication policy/audit log storage.

It also includes a commit that updates the main POM to use HTTPS.