### PR TITLE
DURACLOUD-1271: Update mysql-connector-java dependency version 5.1.38 -> 5.1.49

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -157,7 +157,7 @@
     <org.springframework.security.version>4.0.4.RELEASE</org.springframework.security.version>
     <org.springframework.data.jpa.version>1.10.1.RELEASE</org.springframework.data.jpa.version>
     <hibernate.version>5.1.0.Final</hibernate.version>
-    <mysql.driver.version>5.1.38</mysql.driver.version>
+    <mysql.driver.version>5.1.49</mysql.driver.version>
     <slf4j.version>1.7.6</slf4j.version>
 
     <skipUTs>false</skipUTs>


### PR DESCRIPTION
JIRA ticket: https://jira.lyrasis.org/browse/DURACLOUD-1271

Includes bug fixes and updates that will improve functionality with more recent versions of MySQL. 