### PR TITLE
Updates DuraCloud DB to build and run with Java 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: trusty
 language: java
 jdk:
-  - oraclejdk8
+  - openjdk11
 notifications:
   email:
     recipients:

--- a/account-management-db-repo/pom.xml
+++ b/account-management-db-repo/pom.xml
@@ -50,6 +50,11 @@
       <artifactId>mysql-connector-java</artifactId>
     </dependency>
 
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+    </dependency>
+
   </dependencies>
 
 </project>

--- a/mill-db-repo/pom.xml
+++ b/mill-db-repo/pom.xml
@@ -89,6 +89,11 @@
     </dependency>
 
     <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>com.wix</groupId>
       <artifactId>wix-embedded-mysql</artifactId>
       <version>2.2.3</version>

--- a/mill-db-repo/src/test/java/org/duracloud/mill/auditor/jpa/JpaAuditLogStoreTest.java
+++ b/mill-db-repo/src/test/java/org/duracloud/mill/auditor/jpa/JpaAuditLogStoreTest.java
@@ -25,6 +25,7 @@ import org.duracloud.mill.db.model.JpaAuditLogItem;
 import org.duracloud.mill.db.repo.JpaAuditLogItemRepo;
 import org.duracloud.mill.test.jpa.JpaTestBase;
 import org.easymock.Capture;
+import org.easymock.CaptureType;
 import org.easymock.Mock;
 import org.junit.Test;
 import org.springframework.data.domain.Page;
@@ -68,7 +69,7 @@ public class JpaAuditLogStoreTest extends JpaTestBase<JpaAuditLogItem> {
     @Test
     public void testWrite() throws AuditLogWriteFailedException {
 
-        Capture<JpaAuditLogItem> jpaItemCapture = new Capture<>();
+        Capture<JpaAuditLogItem> jpaItemCapture = Capture.newInstance(CaptureType.FIRST);
 
         expect(repo.saveAndFlush(capture(jpaItemCapture)))
             .andReturn(new JpaAuditLogItem());
@@ -117,7 +118,7 @@ public class JpaAuditLogStoreTest extends JpaTestBase<JpaAuditLogItem> {
     @Test
     public void testGetLogItemsByAccountStoreIdSpaceIdAndContentId() {
         this.auditLogStore = new JpaAuditLogStore(repo);
-        Capture<Pageable> capture = new Capture<>();
+        Capture<Pageable> capture = Capture.newInstance(CaptureType.FIRST);
         int count = 10;
 
         Page<JpaAuditLogItem> page = setupPage(count);

--- a/mill-db-repo/src/test/java/org/duracloud/mill/manifest/jpa/JpaManifestStoreTest.java
+++ b/mill-db-repo/src/test/java/org/duracloud/mill/manifest/jpa/JpaManifestStoreTest.java
@@ -25,6 +25,7 @@ import org.duracloud.mill.db.repo.JpaManifestItemRepo;
 import org.duracloud.mill.manifest.ManifestItemWriteException;
 import org.duracloud.mill.test.jpa.JpaTestBase;
 import org.easymock.Capture;
+import org.easymock.CaptureType;
 import org.easymock.Mock;
 import org.junit.Assert;
 import org.junit.Test;
@@ -56,7 +57,7 @@ public class JpaManifestStoreTest extends JpaTestBase<ManifestItem> {
     @Test
     public void testAdd() throws ManifestItemWriteException {
         createTestSubject();
-        Capture<ManifestItem> capture = new Capture<>();
+        Capture<ManifestItem> capture = Capture.newInstance(CaptureType.FIRST);
         expect(this.repo.findByAccountAndStoreIdAndSpaceIdAndContentId(account,
                                                                        storeId,
                                                                        spaceId,
@@ -179,7 +180,7 @@ public class JpaManifestStoreTest extends JpaTestBase<ManifestItem> {
                                                                        storeId,
                                                                        spaceId,
                                                                        contentId)).andReturn(null);
-        Capture<ManifestItem> itemCapture = new Capture<ManifestItem>();
+        Capture<ManifestItem> itemCapture = Capture.newInstance(CaptureType.FIRST);
 
         expect(repo.saveAndFlush(capture(itemCapture))).andReturn(new ManifestItem());
 

--- a/pom.xml
+++ b/pom.xml
@@ -159,6 +159,7 @@
     <hibernate.version>5.1.0.Final</hibernate.version>
     <mysql.driver.version>5.1.49</mysql.driver.version>
     <slf4j.version>1.7.6</slf4j.version>
+    <jaxb.api.version>2.3.1</jaxb.api.version>
 
     <skipUTs>false</skipUTs>
     <skipITs>true</skipITs>
@@ -290,10 +291,9 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.1</version>
+        <version>3.8.1</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <release>11</release>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
@@ -434,7 +434,7 @@
       <dependency>
         <groupId>org.easymock</groupId>
         <artifactId>easymock</artifactId>
-        <version>3.2</version>
+        <version>4.0.2</version>
         <scope>test</scope>
       </dependency>
 
@@ -608,6 +608,12 @@
         <groupId>net.sf.trove4j</groupId>
         <artifactId>trove4j</artifactId>
         <version>3.0.3</version>
+      </dependency>
+
+      <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>${jaxb.api.version}</version>
       </dependency>
 
     </dependencies>


### PR DESCRIPTION
**JIRA Ticket**: https://jira.lyrasis.org/browse/DURACLOUD-1242

# What does this Pull Request do?

Updates DuraCloud to build and run with Java 11

# How should this be tested?

There should be no functional changes. Testing should include building with Java 11, updating DuraCloud/DuraCloud MC to use this version of DuraCloud DB, then building and running those applications in a Tomcat that is also using Java 11. The more testing to verify that everything is working properly, the better.

# Interested parties
@dbernstein 
@nwoodward 
