### PR TITLE
Explicitly include javassist dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -603,6 +603,12 @@
       </dependency>
 
       <dependency>
+        <groupId>org.javassist</groupId>
+        <artifactId>javassist</artifactId>
+        <version>3.24.0-GA</version>
+      </dependency>
+
+      <dependency>
         <groupId>mysql</groupId>
         <artifactId>mysql-connector-java</artifactId>
         <version>${mysql.driver.version}</version>


### PR DESCRIPTION
The version of javassist that hibernate includes (3.20.0-GA) was causing
workman to fail to start.