### PR TITLE
Update dependencies

### DIFF
--- a/account-management-db-model/pom.xml
+++ b/account-management-db-model/pom.xml
@@ -9,7 +9,6 @@
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.duracloud.db</groupId>
   <artifactId>account-management-db-model</artifactId>
   <version>7.2.0-SNAPSHOT</version>
   <name>Account DB Model</name>

--- a/account-management-db-repo/pom.xml
+++ b/account-management-db-repo/pom.xml
@@ -11,7 +11,6 @@
   </parent>
 
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.duracloud.db</groupId>
   <artifactId>account-management-db-repo</artifactId>
   <version>7.2.0-SNAPSHOT</version>
   <name>Account DB Repositories</name>

--- a/account-management-db-repo/pom.xml
+++ b/account-management-db-repo/pom.xml
@@ -45,8 +45,8 @@
     </dependency>
 
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
     </dependency>
 
     <dependency>

--- a/account-management-db-repo/src/main/java/org/duracloud/account/db/config/AccountJpaRepoConfig.java
+++ b/account-management-db-repo/src/main/java/org/duracloud/account/db/config/AccountJpaRepoConfig.java
@@ -50,10 +50,10 @@ public class AccountJpaRepoConfig {
     @Bean(name = ACCOUNT_REPO_DATA_SOURCE_BEAN, destroyMethod = "close")
     public BasicDataSource accountRepoDataSource() {
         BasicDataSource dataSource = new BasicDataSource();
-        dataSource.setDriverClassName("com.mysql.jdbc.Driver");
+        dataSource.setDriverClassName("com.mysql.cj.jdbc.Driver");
         dataSource.setUrl(MessageFormat.format("jdbc:mysql://{0}:{1}/{2}" +
                                                "?characterEncoding=utf8" +
-                                               "&characxterSetResults=utf8",
+                                               "&characterSetResults=utf8",
                                                env.getProperty(ConfigConstants.MC_DB_HOST, "localhost"),
                                                env.getProperty(ConfigConstants.MC_DB_PORT, "3306"),
                                                env.getProperty(ConfigConstants.MC_DB_NAME, "name")));

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -2,7 +2,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.duracloud.db</groupId>
   <artifactId>common</artifactId>
   <version>7.2.0-SNAPSHOT</version>
   <name>DuraCloud DB Common</name>

--- a/common/src/main/java/org/duracloud/common/collection/jpa/JpaIteratorSource.java
+++ b/common/src/main/java/org/duracloud/common/collection/jpa/JpaIteratorSource.java
@@ -42,7 +42,7 @@ public abstract class JpaIteratorSource<R, T> implements IteratorSource<T> {
         if (currentPage < 0) {
             return null;
         }
-        Page<T> page = getNextPage(new PageRequest(currentPage, maxResults), repo);
+        Page<T> page = getNextPage(PageRequest.of(currentPage, maxResults), repo);
         currentPage++;
         if (page.getTotalPages() == currentPage) {
             currentPage = -1;

--- a/mill-db-repo/pom.xml
+++ b/mill-db-repo/pom.xml
@@ -95,7 +95,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>mysql</artifactId>
-      <version>1.17.6</version>
+      <version>1.19.0</version>
       <scope>test</scope>
     </dependency>
 

--- a/mill-db-repo/pom.xml
+++ b/mill-db-repo/pom.xml
@@ -94,9 +94,9 @@
     </dependency>
 
     <dependency>
-      <groupId>com.wix</groupId>
-      <artifactId>wix-embedded-mysql</artifactId>
-      <version>2.2.3</version>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mysql</artifactId>
+      <version>1.17.6</version>
       <scope>test</scope>
     </dependency>
 

--- a/mill-db-repo/pom.xml
+++ b/mill-db-repo/pom.xml
@@ -2,7 +2,6 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
-  <groupId>org.duracloud.db</groupId>
   <artifactId>mill-db-repo</artifactId>
   <version>7.2.0-SNAPSHOT</version>
   <name>DuraCloud Mill JPA Repositories</name>

--- a/mill-db-repo/pom.xml
+++ b/mill-db-repo/pom.xml
@@ -83,8 +83,8 @@
     </dependency>
 
     <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
     </dependency>
 
     <dependency>

--- a/mill-db-repo/src/main/java/org/duracloud/mill/auditor/jpa/JpaAuditLogStore.java
+++ b/mill-db-repo/src/main/java/org/duracloud/mill/auditor/jpa/JpaAuditLogStore.java
@@ -10,6 +10,7 @@ package org.duracloud.mill.auditor.jpa;
 import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Optional;
 
 import org.duracloud.common.collection.StreamingIterator;
 import org.duracloud.common.collection.jpa.JpaIteratorSource;
@@ -84,6 +85,7 @@ public class JpaAuditLogStore implements AuditLogStore {
                 log.warn(
                     "failed to add audit log item {}: due to data integrity violation: suspected duplicate record: ->" +
                     " message={}",
+                    item.getId(),
                     ex.getMessage());
             } else {
                 throw new AuditLogWriteFailedException(ex, item);
@@ -142,9 +144,11 @@ public class JpaAuditLogStore implements AuditLogStore {
         }
         Long id = ((JpaAuditLogItem) item).getId();
 
-        JpaAuditLogItem refreshedItem = auditLogRepo.findOne(id);
-        refreshedItem.setContentProperties(properties);
-        auditLogRepo.saveAndFlush(refreshedItem);
+        Optional<JpaAuditLogItem> queriedItem = auditLogRepo.findById(id);
+        queriedItem.ifPresent(refreshedItem -> {
+            refreshedItem.setContentProperties(properties);
+            auditLogRepo.saveAndFlush(refreshedItem);
+        });
     }
 
 }

--- a/mill-db-repo/src/main/java/org/duracloud/mill/db/repo/MillJpaRepoConfig.java
+++ b/mill-db-repo/src/main/java/org/duracloud/mill/db/repo/MillJpaRepoConfig.java
@@ -52,7 +52,7 @@ public class MillJpaRepoConfig {
     @Bean(name = MILL_REPO_DATA_SOURCE_BEAN, destroyMethod = "close")
     public BasicDataSource millRepoDataSource() {
         BasicDataSource dataSource = new BasicDataSource();
-        dataSource.setDriverClassName("com.mysql.jdbc.Driver");
+        dataSource.setDriverClassName("com.mysql.cj.jdbc.Driver");
         dataSource.setUrl(MessageFormat.format("jdbc:mysql://{0}:{1}/{2}" +
                                                "?useLegacyDatetimeCode=false" +
                                                "&serverTimezone=GMT" +

--- a/mill-db-repo/src/test/java/org/duracloud/mill/auditor/jpa/JpaAuditLogStoreTest.java
+++ b/mill-db-repo/src/test/java/org/duracloud/mill/auditor/jpa/JpaAuditLogStoreTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertNotNull;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.Iterator;
+import java.util.Optional;
 
 import org.duracloud.common.db.error.NotFoundException;
 import org.duracloud.mill.auditor.AuditLogItem;
@@ -59,9 +60,9 @@ public class JpaAuditLogStoreTest extends JpaTestBase<JpaAuditLogItem> {
 
     /**
      * Test method for
-     * {@link org.duracloud.mill.auditor.jpa.JpaAuditLogStore#write(java.lang.String, java.lang.String, java.lang
-     * .String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang
-     * .String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date)}
+     * {@link org.duracloud.mill.auditor.jpa.JpaAuditLogStore#write(java.lang.String, java.lang.String,
+     * java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String,
+     * java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.lang.String, java.util.Date)}
      * .
      *
      * @throws AuditLogWriteFailedException
@@ -173,7 +174,7 @@ public class JpaAuditLogStoreTest extends JpaTestBase<JpaAuditLogItem> {
         String serializedProps = "{}";
 
         JpaAuditLogItem freshItem = createMock(JpaAuditLogItem.class);
-        expect(repo.findOne(eq(id))).andReturn(freshItem);
+        expect(repo.findById(eq(id))).andReturn(Optional.of(freshItem));
         freshItem.setContentProperties(serializedProps);
         expectLastCall().once();
         expect(repo.saveAndFlush(freshItem)).andReturn(freshItem);

--- a/mill-db-repo/src/test/java/org/duracloud/mill/manifest/jpa/ManifestStoreIntegrationTest.java
+++ b/mill-db-repo/src/test/java/org/duracloud/mill/manifest/jpa/ManifestStoreIntegrationTest.java
@@ -19,6 +19,7 @@ import org.duracloud.mill.db.model.ManifestItem;
 import org.duracloud.mill.manifest.ManifestItemWriteException;
 import org.duracloud.mill.manifest.ManifestStore;
 import org.duracloud.mill.test.jpa.JpaIntegrationTestBase;
+import org.junit.After;
 import org.junit.Test;
 
 /**
@@ -169,6 +170,15 @@ public class ManifestStoreIntegrationTest extends JpaIntegrationTestBase {
     @Test(expected = ManifestItemWriteException.class)
     public void updateMissingFromStorageProviderFlagNotFound() throws Exception {
         getStore().updateMissingFromStorageProviderFlag(account, storeId, spaceId, contentId, true);
+    }
+
+    @After
+    public void tearDown() {
+        try {
+            getStore().delete(account, storeId, spaceId);
+        } catch (final Exception ignored) {
+            // ...ignored
+        }
     }
 
     private ManifestStore getStore() {

--- a/mill-db-repo/src/test/java/org/duracloud/mill/test/jpa/JpaIntegrationTestBase.java
+++ b/mill-db-repo/src/test/java/org/duracloud/mill/test/jpa/JpaIntegrationTestBase.java
@@ -15,7 +15,6 @@ import org.junit.ClassRule;
 import org.junit.runner.RunWith;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.testcontainers.containers.MySQLContainer;
-import org.testcontainers.utility.DockerImageName;
 
 /**
  * @author Daniel Bernstein
@@ -25,7 +24,7 @@ import org.testcontainers.utility.DockerImageName;
 public abstract class JpaIntegrationTestBase extends EasyMockSupport {
 
     @ClassRule
-    public static MySQLContainer<?> mysql = new MySQLContainer<>(DockerImageName.parse("mysql:5.7-debian"))
+    public static MySQLContainer<?> mysql = new MySQLContainer<>()
         .withUsername("user")
         .withPassword("pass")
         .withDatabaseName("mill")

--- a/mill-db-repo/src/test/resources/db_init.sql
+++ b/mill-db-repo/src/test/resources/db_init.sql
@@ -1,2 +1,1 @@
-grant all privileges on mill.* to "user"@"localhost" identified by "pass";
-flush privileges;
+ALTER DATABASE mill CHARACTER SET utf8 COLLATE utf8_general_ci;

--- a/pom.xml
+++ b/pom.xml
@@ -450,7 +450,7 @@
       <dependency>
         <groupId>ch.qos.logback</groupId>
         <artifactId>logback-classic</artifactId>
-        <version>1.2.0</version>
+        <version>1.2.9</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -157,8 +157,8 @@
     <log.level.default>INFO</log.level.default>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <duraspace-codestyle.version>1.1.0</duraspace-codestyle.version>
-    <org.springframework.version>5.3.25</org.springframework.version>
-    <org.springframework.security.version>5.8.2</org.springframework.security.version>
+    <org.springframework.version>5.3.27</org.springframework.version>
+    <org.springframework.security.version>5.8.3</org.springframework.security.version>
     <org.springframework.data.jpa.version>2.7.7</org.springframework.data.jpa.version>
     <org.springframework.data.commons.version>2.7.7</org.springframework.data.commons.version>
     <hibernate.version>5.4.33.Final</hibernate.version>

--- a/pom.xml
+++ b/pom.xml
@@ -162,7 +162,7 @@
     <org.springframework.data.jpa.version>2.7.7</org.springframework.data.jpa.version>
     <org.springframework.data.commons.version>2.7.7</org.springframework.data.commons.version>
     <hibernate.version>5.4.33.Final</hibernate.version>
-    <mysql.driver.version>5.1.49</mysql.driver.version>
+    <mysql.driver.version>8.0.33</mysql.driver.version>
     <slf4j.version>1.7.6</slf4j.version>
     <jaxb.api.version>2.3.1</jaxb.api.version>
 
@@ -625,9 +625,15 @@
       </dependency>
 
       <dependency>
-        <groupId>mysql</groupId>
-        <artifactId>mysql-connector-java</artifactId>
+        <groupId>com.mysql</groupId>
+        <artifactId>mysql-connector-j</artifactId>
         <version>${mysql.driver.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.protobuf</groupId>
+            <artifactId>protobuf-java</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -474,7 +474,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.1</version>
+        <version>3.12.0</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
     <org.springframework.security.version>5.8.2</org.springframework.security.version>
     <org.springframework.data.jpa.version>2.7.7</org.springframework.data.jpa.version>
     <org.springframework.data.commons.version>2.7.7</org.springframework.data.commons.version>
-    <hibernate.version>5.6.14.Final</hibernate.version>
+    <hibernate.version>5.4.33.Final</hibernate.version>
     <mysql.driver.version>5.1.49</mysql.driver.version>
     <slf4j.version>1.7.6</slf4j.version>
     <jaxb.api.version>2.3.1</jaxb.api.version>
@@ -581,28 +581,23 @@
         </exclusions>
       </dependency>
 
+      <!-- there's converge issue with hibernate modules so manage this here -->
+      <dependency>
+        <groupId>org.jboss.logging</groupId>
+        <artifactId>jboss-logging</artifactId>
+        <version>3.4.1.Final</version>
+      </dependency>
+
       <dependency>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-core</artifactId>
         <version>${hibernate.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <dependency>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-entitymanager</artifactId>
         <version>${hibernate.version}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
 
       <dependency>
@@ -610,10 +605,6 @@
         <artifactId>hibernate-validator</artifactId>
         <version>${hibernate.version}</version>
         <exclusions>
-          <exclusion>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
-          </exclusion>
           <exclusion>
             <groupId>com.fasterxml</groupId>
             <artifactId>classmate</artifactId>
@@ -651,6 +642,13 @@
         <version>${jaxb.api.version}</version>
       </dependency>
 
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers-bom</artifactId>
+        <version>1.17.6</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -437,7 +437,7 @@
       <dependency>
         <groupId>org.easymock</groupId>
         <artifactId>easymock</artifactId>
-        <version>4.0.2</version>
+        <version>5.1.0</version>
         <scope>test</scope>
       </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -157,10 +157,11 @@
     <log.level.default>INFO</log.level.default>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <duraspace-codestyle.version>1.1.0</duraspace-codestyle.version>
-    <org.springframework.version>4.3.30.RELEASE</org.springframework.version>
-    <org.springframework.security.version>4.2.20.RELEASE</org.springframework.security.version>
-    <org.springframework.data.jpa.version>1.11.23.RELEASE</org.springframework.data.jpa.version>
-    <hibernate.version>5.4.3.Final</hibernate.version>
+    <org.springframework.version>5.3.25</org.springframework.version>
+    <org.springframework.security.version>5.8.2</org.springframework.security.version>
+    <org.springframework.data.jpa.version>2.7.7</org.springframework.data.jpa.version>
+    <org.springframework.data.commons.version>2.7.7</org.springframework.data.commons.version>
+    <hibernate.version>5.6.14.Final</hibernate.version>
     <mysql.driver.version>5.1.49</mysql.driver.version>
     <slf4j.version>1.7.6</slf4j.version>
     <jaxb.api.version>2.3.1</jaxb.api.version>
@@ -559,7 +560,7 @@
       <dependency>
         <groupId>org.springframework.data</groupId>
         <artifactId>spring-data-commons</artifactId>
-        <version>1.13.23.RELEASE</version>
+        <version>${org.springframework.data.commons.version}</version>
       </dependency>
 
       <dependency>
@@ -584,12 +585,24 @@
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-core</artifactId>
         <version>${hibernate.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-entitymanager</artifactId>
         <version>${hibernate.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.jboss.logging</groupId>
+            <artifactId>jboss-logging</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -157,10 +157,10 @@
     <log.level.default>INFO</log.level.default>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <duraspace-codestyle.version>1.1.0</duraspace-codestyle.version>
-    <org.springframework.version>5.3.27</org.springframework.version>
-    <org.springframework.security.version>5.8.3</org.springframework.security.version>
-    <org.springframework.data.jpa.version>2.7.7</org.springframework.data.jpa.version>
-    <org.springframework.data.commons.version>2.7.7</org.springframework.data.commons.version>
+    <org.springframework.version>5.3.29</org.springframework.version>
+    <org.springframework.security.version>5.8.5</org.springframework.security.version>
+    <org.springframework.data.jpa.version>2.7.15</org.springframework.data.jpa.version>
+    <org.springframework.data.commons.version>2.7.15</org.springframework.data.commons.version>
     <hibernate.version>5.4.33.Final</hibernate.version>
     <mysql.driver.version>8.0.33</mysql.driver.version>
     <slf4j.version>1.7.6</slf4j.version>

--- a/pom.xml
+++ b/pom.xml
@@ -641,14 +641,6 @@
         <artifactId>jaxb-api</artifactId>
         <version>${jaxb.api.version}</version>
       </dependency>
-
-      <dependency>
-        <groupId>org.testcontainers</groupId>
-        <artifactId>testcontainers-bom</artifactId>
-        <version>1.17.6</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Jira: ? 

# Changes

* Update spring dependencies for 5 support
* Replace wix with testcontainers for mysql testing
* Bump easymock and hibernate dependencies
* Set jboss-logging version to avoid dependency conflict

# Notes

I had to do some configuration on my environment to get testcontainers to run properly for me because my docker ran as root only previously. This makes testing a little harder by default and adds an external dependency, but also allows use of an actual mysql db. I don't believe there should be any changes necessary for the gitlab ci to work correctly. @dbernstein let me know what you think.

There were a few small changes I had to make to the tests to get everything to work. Notably, setting the charset and collate for the mill database and removing any data saved after tests were run (I think the embedded db was being recreated on each test before).

There are also a few small api updates from the spring-data updates, I think `findOne` -> `findById` is the most significant. 